### PR TITLE
Add footer component and use across pages

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import logo from '../assets/images/logo2.png';
+
+const Footer = () => (
+  <footer className="bg-dark text-white mt-auto py-4">
+    <div className="container text-center">
+      <img src={logo} alt="Surprise of Love" style={{ height: '40px' }} className="mb-2" />
+      <ul className="list-inline mb-3">
+        <li className="list-inline-item">
+          <Link to="/about" className="text-white text-decoration-none">About</Link>
+        </li>
+        <li className="list-inline-item">
+          <Link to="/faq" className="text-white text-decoration-none">FAQ</Link>
+        </li>
+        <li className="list-inline-item">
+          <Link to="/returns" className="text-white text-decoration-none">Returns</Link>
+        </li>
+        <li className="list-inline-item">
+          <Link to="/contact" className="text-white text-decoration-none">Contact</Link>
+        </li>
+      </ul>
+      <p className="mb-0 small">&copy; {new Date().getFullYear()} Surprise of Love</p>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const AboutPage = () => (
   <div className="font-sans">
@@ -8,6 +9,7 @@ const AboutPage = () => (
       <h1 className="mb-4">About Us</h1>
       <p>We are passionate about offering unique gifts that create lasting memories. Our products are carefully selected and handcrafted with love.</p>
     </div>
+    <Footer />
   </div>
 );
 

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useCart } from '../context/CartContext';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 import { useNavigate } from 'react-router-dom';
 
 const CartPage = () => {
@@ -71,6 +72,7 @@ const CartPage = () => {
           </>
         )}
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const ContactPage = () => {
   const [form, setForm] = useState({ name: '', email: '', message: '' });
@@ -31,6 +32,7 @@ const ContactPage = () => {
           <button className="btn btn-primary" type="submit">Send</button>
         </form>
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/FaqPage.jsx
+++ b/src/pages/FaqPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const FaqPage = () => (
   <div className="font-sans">
@@ -29,6 +30,7 @@ const FaqPage = () => (
         </div>
       </div>
     </div>
+    <Footer />
   </div>
 );
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 import testImage from '../assets/images/test.jpg';
 import mainImage from '../assets/images/169main.jpg';
 import BestSellerSlider from '../components/BestSellerSlider';
@@ -55,6 +56,7 @@ const Homepage = () => {
       {/* Product Preview */}
           <BestSellerSlider />
 
+      <Footer />
     </div>
   );
 };

--- a/src/pages/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 import { useCart } from '../context/CartContext';
 import ImageCarousel from '../components/ImageCarousel';
 
@@ -150,6 +151,7 @@ const ProductDetailPage = () => {
           </div>
         </div>
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 import ProductCard from '../components/ProductCard';
 const ProductsPage = () => {
   const [products, setProducts] = useState([]);
@@ -24,7 +25,7 @@ const ProductsPage = () => {
   }, []);
 
   return (
-    <div style={{ minHeight: '100vh' }}>
+    <div className="min-vh-100 d-flex flex-column">
       <Navbar />
 
       <section className="py-5 bg-light">
@@ -46,6 +47,7 @@ const ProductsPage = () => {
           )}
         </div>
       </section>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/ReturnPolicyPage.jsx
+++ b/src/pages/ReturnPolicyPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const ReturnPolicyPage = () => (
   <div className="font-sans">
@@ -8,6 +9,7 @@ const ReturnPolicyPage = () => (
       <h1 className="mb-4">Return & Refund Policy</h1>
       <p>If you are not satisfied with your purchase, you can return the product within 30 days for a full refund.</p>
     </div>
+    <Footer />
   </div>
 );
 

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const ThankYouPage = () => {
   return (
@@ -24,6 +25,7 @@ const ThankYouPage = () => {
           <Link to="/" className="btn btn-primary px-4 py-2 rounded-pill">Continue Shopping</Link>
         </div>
       </main>
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create reusable `Footer` component
- include footer on primary user pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e150b894883259128496c3fc347bd