### PR TITLE
Add wishlist context with local storage

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { Menu, ShoppingCart } from 'lucide-react';
+import { Menu, ShoppingCart, Heart } from 'lucide-react';
 import logo from '../assets/images/logo2.png';
 import { Link } from 'react-router-dom';
 import { useCart } from '../context/CartContext';
+import { useWishlist } from '../context/WishlistContext';
 import TopBanner from '../components/TopBanner';
 
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { cart } = useCart();
+  const { wishlist } = useWishlist();
 
   const toggleMenu = () => setIsOpen(!isOpen);
 
@@ -21,14 +23,24 @@ const Navbar = () => {
             <Menu className="w-6 h-6" />
           </button>
           <img src={logo} alt="Surprise of Love" style={{ height: '64px' }} />
-          <Link to="/cart" className="text-dark position-relative">
-            <ShoppingCart className="w-6 h-6" />
-            {cart.length > 0 && (
-              <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
-                {cart.length}
-              </span>
-            )}
-          </Link>
+          <div className="d-flex align-items-center gap-3">
+            <span className="position-relative">
+              <Heart />
+              {wishlist.length > 0 && (
+                <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                  {wishlist.length}
+                </span>
+              )}
+            </span>
+            <Link to="/cart" className="text-dark position-relative">
+              <ShoppingCart className="w-6 h-6" />
+              {cart.length > 0 && (
+                <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                  {cart.length}
+                </span>
+              )}
+            </Link>
+          </div>
         </div>
 
         {isOpen && (

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -1,18 +1,31 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const CartContext = createContext();
 
 export const useCart = () => useContext(CartContext);
 
 export const CartProvider = ({ children }) => {
-  const [cart, setCart] = useState([]);
+  const [cart, setCart] = useState(() => {
+    const stored = localStorage.getItem('cart');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }, [cart]);
 
   const addToCart = (product) => {
     setCart((prev) => [...prev, product]);
   };
 
+  const removeFromCart = (id) => {
+    setCart((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const clearCart = () => setCart([]);
+
   return (
-    <CartContext.Provider value={{ cart, addToCart, setCart }}>
+    <CartContext.Provider value={{ cart, addToCart, removeFromCart, clearCart, setCart }}>
       {children}
     </CartContext.Provider>
   );

--- a/src/context/WishlistContext.jsx
+++ b/src/context/WishlistContext.jsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const WishlistContext = createContext();
+
+export const useWishlist = () => useContext(WishlistContext);
+
+export const WishlistProvider = ({ children }) => {
+  const [wishlist, setWishlist] = useState(() => {
+    const stored = localStorage.getItem('wishlist');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('wishlist', JSON.stringify(wishlist));
+  }, [wishlist]);
+
+  const addToWishlist = (product) => {
+    setWishlist((prev) => [...prev, product]);
+  };
+
+  const removeFromWishlist = (id) => {
+    setWishlist((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const isWishlisted = (id) => wishlist.some((item) => item.id === id);
+
+  return (
+    <WishlistContext.Provider
+      value={{ wishlist, addToWishlist, removeFromWishlist, isWishlisted, setWishlist }}
+    >
+      {children}
+    </WishlistContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,12 +5,15 @@ import './index.css';
 import App from './App.jsx';
 import { CartProvider } from './context/CartContext.jsx';
 import { AuthProvider } from './context/AuthContext.jsx';
+import { WishlistProvider } from './context/WishlistContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
       <CartProvider>
-        <App />
+        <WishlistProvider>
+          <App />
+        </WishlistProvider>
       </CartProvider>
     </AuthProvider>
   </StrictMode>

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -5,11 +5,11 @@ import Footer from '../components/Footer';
 import { useNavigate } from 'react-router-dom';
 
 const CartPage = () => {
-  const { cart, setCart } = useCart();
+  const { cart, setCart, removeFromCart } = useCart();
   const navigate = useNavigate();
 
   const handleRemove = (id) => {
-    setCart(cart.filter(item => item.id !== id));
+    removeFromCart(id);
   };
 
   const handleQuantityChange = (id, delta) => {

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -5,7 +5,7 @@ import { db } from '../firebase';
 import { collection, addDoc } from 'firebase/firestore';
 
 const CheckoutPage = () => {
-  const { cart, setCart } = useCart();
+  const { cart, clearCart } = useCart();
   const navigate = useNavigate();
   const navigateRef = useRef(navigate);
   const [userData, setUserData] = useState({ name: '', email: '', address: '' });
@@ -34,7 +34,7 @@ const CheckoutPage = () => {
         }),
         onApprove: (data, actions) => actions.order.capture().then(() => {
           navigateRef.current('/thankyou');
-          setTimeout(() => setCart([]), 100);
+          setTimeout(() => clearCart(), 100);
         })
       }).render('#paypal-button-container');
     });

--- a/src/pages/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage.jsx
@@ -5,11 +5,13 @@ import { db } from '../firebase';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import { useCart } from '../context/CartContext';
+import { useWishlist } from '../context/WishlistContext';
 import ImageCarousel from '../components/ImageCarousel';
 
 const ProductDetailPage = () => {
   const { id } = useParams();
   const { addToCart } = useCart();
+  const { wishlist, addToWishlist, removeFromWishlist } = useWishlist();
   const [product, setProduct] = useState(null);
   const [loading, setLoading] = useState(true);
   const [wish, setWish] = useState(false);
@@ -41,6 +43,10 @@ const ProductDetailPage = () => {
     return () => clearInterval(timer);
   }, []);
 
+  useEffect(() => {
+    setWish(wishlist.some((item) => item.id === id));
+  }, [id, wishlist]);
+
   const formatTime = (sec) => {
     const m = Math.floor(sec / 60).toString().padStart(2, '0');
     const s = (sec % 60).toString().padStart(2, '0');
@@ -56,6 +62,19 @@ const ProductDetailPage = () => {
     });
     setShowPopup(true);
     setTimeout(() => setShowPopup(false), 1500);
+  };
+
+  const handleWishlist = () => {
+    if (wish) {
+      removeFromWishlist(product.id);
+    } else {
+      addToWishlist({
+        id: product.id,
+        name: product.title,
+        price: product.discountPrice || product.price,
+        image: product.images?.[0],
+      });
+    }
   };
 
   if (loading) return <p className="text-center mt-5">Laden...</p>;
@@ -104,7 +123,7 @@ const ProductDetailPage = () => {
               )}
             </h3>
 
-            <button className="btn btn-outline-secondary mb-2" onClick={() => setWish(!wish)}>
+            <button className="btn btn-outline-secondary mb-2" onClick={handleWishlist}>
               {wish ? 'Wishlisted' : 'Add to Wishlist'}
             </button>
 


### PR DESCRIPTION
## Summary
- persist cart contents in local storage
- add new `WishlistContext` to store wishlist items in local storage
- display wishlist count in navbar
- hook wishlist into product detail page
- clear cart after successful payment
- adjust cart page to use context helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e296ba1c88325b31962845f6ce22d