### PR TITLE
Add Stripe checkout option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
+STRIPE_SECRET_KEY=your_stripe_secret_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Stripe Checkout Server
+
+To enable Stripe payments, create a `.env` file based on `.env.example` and fill in your Stripe keys.
+
+Start the development server with:
+
+```bash
+npm run server
+```
+
+This provides an endpoint at `http://localhost:3001/create-checkout-session` that the app uses to start Stripe Checkout.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "deploy": "gh-pages -d dist",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "axios": "^1.9.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import Stripe from 'stripe';
+import cors from 'cors';
+
+const app = express();
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+  apiVersion: '2023-10-16',
+});
+
+app.use(cors());
+app.use(express.json());
+
+app.post('/create-checkout-session', async (req, res) => {
+  try {
+    const { items } = req.body;
+    if (!Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ error: 'No items provided' });
+    }
+
+    const lineItems = items.map((item) => ({
+      price_data: {
+        currency: 'eur',
+        product_data: { name: item.name },
+        unit_amount: Math.round(item.price * 100),
+      },
+      quantity: item.quantity || 1,
+    }));
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      mode: 'payment',
+      line_items: lineItems,
+      success_url: `${req.headers.origin}/thankyou`,
+      cancel_url: `${req.headers.origin}/cart`,
+    });
+
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error('Stripe session error:', err);
+    res.status(500).json({ error: 'Failed to create session' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -13,6 +13,7 @@ const CartPage = () => {
 
   const [showOffer, setShowOffer] = useState(false);
   const [offerItem, setOfferItem] = useState(null);
+  const [paymentPlatform, setPaymentPlatform] = useState('paypal');
 
   const handleRemove = (id) => {
     removeFromCart(id);
@@ -31,6 +32,25 @@ const CartPage = () => {
       sum + (item.price * (item.quantity || 1)), 0).toFixed(2);
   };
 
+  const startStripeCheckout = async () => {
+    try {
+      const res = await fetch('http://localhost:3001/create-checkout-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: cart }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        alert('Kan Stripe Checkout niet starten.');
+      }
+    } catch (err) {
+      console.error('Stripe session error:', err);
+      alert('Kan Stripe Checkout niet starten.');
+    }
+  };
+
   const handleCheckoutClick = async () => {
     try {
       const snap = await getDocs(collection(db, 'products'));
@@ -39,18 +59,26 @@ const CartPage = () => {
       const cartIds = cart.map(item => item.id);
       const filteredItems = allItems.filter(item => !cartIds.includes(item.id));
 
-      if (filteredItems.length > 0) {
-        const random = filteredItems[Math.floor(Math.random() * filteredItems.length)];
-        setOfferItem(random);
-        setShowOffer(true);
-      } else {
-        navigate('/checkout');
+        if (filteredItems.length > 0) {
+          const random = filteredItems[Math.floor(Math.random() * filteredItems.length)];
+          setOfferItem(random);
+          setShowOffer(true);
+        } else {
+          if (paymentPlatform === 'stripe') {
+            startStripeCheckout();
+          } else {
+            navigate('/checkout');
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch offer item:", err);
+        if (paymentPlatform === 'stripe') {
+          startStripeCheckout();
+        } else {
+          navigate('/checkout');
+        }
       }
-    } catch (err) {
-      console.error("Failed to fetch offer item:", err);
-      navigate('/checkout');
-    }
-  };
+    };
 
   const acceptOffer = () => {
     if (offerItem) {
@@ -66,7 +94,19 @@ const CartPage = () => {
         },
       ]);
     }
-    navigate('/checkout');
+    if (paymentPlatform === 'stripe') {
+      startStripeCheckout();
+    } else {
+      navigate('/checkout');
+    }
+  };
+
+  const redirectWithoutOffer = () => {
+    if (paymentPlatform === 'stripe') {
+      startStripeCheckout();
+    } else {
+      navigate('/checkout');
+    }
   };
 
   return (
@@ -107,19 +147,47 @@ const CartPage = () => {
                   </div>
                 </div>
               </div>
-            ))}
+              ))}
 
-            {parseFloat(getSubtotal()) >= 30 && (
-              <div className="alert alert-success text-center fw-semibold mt-3 rounded-pill shadow-sm">
-                🎉 Gratis verzending vanaf €30! Goed bezig!
+              {parseFloat(getSubtotal()) >= 30 && (
+                <div className="alert alert-success text-center fw-semibold mt-3 rounded-pill shadow-sm">
+                  🎉 Gratis verzending vanaf €30! Goed bezig!
+                </div>
+              )}
+
+              <div className="mt-4">
+                <h5 className="fw-bold mb-2">Betaalplatform</h5>
+                <div className="form-check">
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    id="pay-paypal"
+                    checked={paymentPlatform === 'paypal'}
+                    onChange={() => setPaymentPlatform('paypal')}
+                  />
+                  <label className="form-check-label" htmlFor="pay-paypal">
+                    PayPal
+                  </label>
+                </div>
+                <div className="form-check">
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    id="pay-stripe"
+                    checked={paymentPlatform === 'stripe'}
+                    onChange={() => setPaymentPlatform('stripe')}
+                  />
+                  <label className="form-check-label" htmlFor="pay-stripe">
+                    Creditcard (Stripe)
+                  </label>
+                </div>
               </div>
-            )}
 
-            <div className="text-end mt-4">
-              <h4 className="fw-bold">Totaal: €{getSubtotal()}</h4>
-              <button className="btn btn-dark mt-3 px-5 py-2 rounded-pill fw-semibold shadow-sm" onClick={handleCheckoutClick}>
-                Doorgaan naar Afrekenen
-              </button>
+              <div className="text-end mt-4">
+                <h4 className="fw-bold">Totaal: €{getSubtotal()}</h4>
+                <button className="btn btn-dark mt-3 px-5 py-2 rounded-pill fw-semibold shadow-sm" onClick={handleCheckoutClick}>
+                  Doorgaan naar Afrekenen
+                </button>
             </div>
           </>
         )}
@@ -137,7 +205,7 @@ const CartPage = () => {
               <div className="modal-content shadow border-0 rounded-4">
                 <div className="modal-header border-0">
                   <h5 className="modal-title fs-4">✨ Speciale Aanbieding</h5>
-                  <button type="button" className="btn-close" onClick={() => navigate('/checkout')}></button>
+                  <button type="button" className="btn-close" onClick={redirectWithoutOffer}></button>
                 </div>
                 <div className="modal-body text-center">
                   <img src={offerItem.images?.[0]} alt={offerItem.title} className="img-fluid mb-4 rounded shadow-sm" style={{ maxHeight: '240px' }} />
@@ -153,7 +221,7 @@ const CartPage = () => {
                 </div>
                 <div className="modal-footer d-flex justify-content-center border-0 pb-4">
                   <button className="btn btn-success px-4 rounded-pill shadow-sm" onClick={acceptOffer}>Hell yeah!</button>
-                  <button className="btn btn-outline-secondary px-4 rounded-pill shadow-sm" onClick={() => navigate('/checkout')}>Nee, doorgaan</button>
+                  <button className="btn btn-outline-secondary px-4 rounded-pill shadow-sm" onClick={redirectWithoutOffer}>Nee, doorgaan</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- allow choosing PayPal or Stripe on the cart page
- create Stripe Checkout session server
- document Stripe server setup in README
- ignore local `.env` files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f4fa904ec8325b5cdfdf205f66e41